### PR TITLE
Fix performance issues on block updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please visit my new Wiki: http://defeatedcrow.jp/modwiki/HeatAndClimate
 - MinecraftForge 14.23.3.2655+  
    
 ## ライセンス
-- このmodは以下のライセンスの元で公開されます。 <br>
+このmodは以下のライセンスの元で公開されます。 <br>
  This mod is distributed under the following license: CC-BY-NC-SA 4.0 <br>
  https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ the Mod necessary for defeatedcrow's mod in 1.12.2
 Please visit my new Wiki: http://defeatedcrow.jp/modwiki/HeatAndClimate
 
 ## Introduction
-- This mod is API and core mod necessary for defeatedcrow's mod in 1.9+. Of course, you can stand-alone use this mod, or use in your modding. <br>このmodは1.9+においてdefeatedcrowが作成するmodの前提MODです。もちろん、このmodを単独で使用したり、あなたのmodの前提modとしても利用することが出来ます。
+This mod is API and core mod necessary for defeatedcrow's mod in 1.9+. Of course, you can stand-alone use this mod, or use in your modding. <br>このmodは1.9+においてdefeatedcrowが作成するmodの前提MODです。もちろん、このmodを単独で使用したり、あなたのmodの前提modとしても利用することが出来ます。
 
 ## 動作環境 Current operating environment:
 - Minecraft 1.12.2

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Please visit my new Wiki: http://defeatedcrow.jp/modwiki/HeatAndClimate
 - MinecraftForge 14.23.3.2655+  
    
 ## ライセンス
-- このmodは以下のライセンスの元で公開されます。
-- This mod is distributed under the following license: CC-BY-NC-SA 4.0 <br>
+- このmodは以下のライセンスの元で公開されます。 <br>
+ This mod is distributed under the following license: CC-BY-NC-SA 4.0 <br>
  https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
 
 The SA clause of the license is excluded in the following cases:

--- a/README.md
+++ b/README.md
@@ -11,17 +11,26 @@ This mod is API and core mod necessary for defeatedcrow's mod in 1.9+. Of course
 - Minecraft 1.12.2
 - MinecraftForge 14.23.3.2655+  
    
-## ライセンス
+## ライセンス Licenses
 このmodは以下のライセンスの元で公開されます。 <br>
- This mod is distributed under the following license: CC-BY-NC-SA 4.0 <br>
+This mod is distributed under the following license:
+### Code: All Rights Reserved
+#### Permissions
+- ソースコードを改変したり、あなたのmodプロジェクトに利用することができます。<br>You can fork, modify, or use the code in your project.
+- このmodの非改変パッケージをmodpackに同梱したり、マルチプレイサーバー内で再配布することができます。<br>You can redistribute this mod's unmodified package to modpack or multiplayer server.
+
+#### Conditions
+- 著作権者の表示 Copyright notice
+- 商用利用禁止 Commercial use prohibition
+
+#### Limitations
+- このmodは「現状のまま」提供され、一切の動作を保証しません。<br>This mod is provided "as is" without warranty of any kind.
+- 作者および著作権者は、いかなる場合でも、このmodの使用その他によって生じる責任を負いません。<br>In any case, the author or copyright holder is not responsible for any claims, damages or other liabilities arising out of this mod or its use.
+
+### Assets: CC-BY-NC-SA 4.0 <br>
  https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
 
-The SA clause of the license is excluded in the following cases:
-- When used to creating add-ons or plugins for this mod (as your MinecraftJE mod).
-- When this mod is bundled with modpack for MinecraftJE.
-- When you take the game playing videos of MinecraftJE that introduced this mod.
-
-## 注意事項
+## 注意事項 Caution!
 1. Now this mod is still WIP. The correct operation cannot be expected. Please be careful! <br> 当modは開発途中です。正常に動作しない場合がありますので、ご了承の上でご利用下さい。<br>
 2. About PR  This mod is authored only by defeatedcrow. PR contributor is treated as contributor, but the contributors do not have a licensing rights of this mod.  In addition, for lang file PR, please use child repository. <br> 当modへPRする場合、当modのContributorとして扱われ、当modのライセンス権を持たないことにご了承下さい。また、langファイルへのPRはこのリポジトリではなく、langファイル管理用の子リポジトリをご利用下さい。  <br>
 
@@ -37,4 +46,4 @@ The SA clause of the license is excluded in the following cases:
 <br>
 3. Climate damage and prevent material. <br>Too high or low temp will hurt player and mobs. It can prevent easily by armors or charms.<br> 極度の高温・低温でプレイヤーやMOBがダメージを受けるようになります。ダメージは防具やアクセサリーで簡単に防ぐことができます。(防具を身につける動機付けです。)<br><br>
 
-(c) defeatedcrow 2016
+Copyright (c) defeatedcrow 2016

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Please visit my new Wiki: http://defeatedcrow.jp/modwiki/HeatAndClimate
 - MinecraftForge 14.23.3.2655+  
    
 ## ライセンス
-- This mod is distributed under the following license: CC-BY-NC-SA 4.0
+- このmodは以下のライセンスの元で公開されます。
+- This mod is distributed under the following license: CC-BY-NC-SA 4.0 <br>
  https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
 
 The SA clause of the license is excluded in the following cases:

--- a/java/defeatedcrow/hac/api/climate/ClimateSupplier.java
+++ b/java/defeatedcrow/hac/api/climate/ClimateSupplier.java
@@ -1,0 +1,24 @@
+package defeatedcrow.hac.api.climate;
+
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.function.Supplier;
+
+public class ClimateSupplier implements Supplier<IClimate> {
+    private IClimate cached;
+    private World world;
+    private BlockPos pos;
+
+    public ClimateSupplier(World world, BlockPos pos) {
+        this.world = world;
+        this.pos = pos;
+    }
+
+    @Override
+    public IClimate get() {
+        if(cached == null)
+            cached = ClimateAPI.calculator.getClimate(world, pos);
+        return cached;
+    }
+}

--- a/java/defeatedcrow/hac/api/recipe/IClimateSmeltingRegister.java
+++ b/java/defeatedcrow/hac/api/recipe/IClimateSmeltingRegister.java
@@ -1,6 +1,7 @@
 package defeatedcrow.hac.api.recipe;
 
 import java.util.List;
+import java.util.function.Supplier;
 
 import defeatedcrow.hac.api.climate.DCAirflow;
 import defeatedcrow.hac.api.climate.DCHeatTier;
@@ -13,7 +14,7 @@ public interface IClimateSmeltingRegister {
 	/**
 	 * Recipeのリストを得る。HeatTierごとに別リストになっている。
 	 */
-	List<? extends IClimateSmelting> getRecipeList(DCHeatTier tier);
+	List<? extends IClimateSmelting> getRecipeList();
 
 	/**
 	 * Recipe登録<br>
@@ -45,11 +46,13 @@ public interface IClimateSmeltingRegister {
 	/**
 	 * coreのClimateSmelting.class以外受け付けないのでご注意を(要本体)
 	 */
-	void addRecipe(IClimateSmelting recipe, DCHeatTier heat);
+	void addRecipe(IClimateSmelting recipe);
 
 	/**
 	 * input, Climateでレシピを判定
 	 */
+	IClimateSmelting getRecipe(Supplier<IClimate> clm, ItemStack item);
+
 	IClimateSmelting getRecipe(IClimate clm, ItemStack item);
 
 	IClimateSmelting getRecipe(int code, ItemStack item);

--- a/java/defeatedcrow/hac/core/DCRecipe.java
+++ b/java/defeatedcrow/hac/core/DCRecipe.java
@@ -122,29 +122,29 @@ public class DCRecipe {
 		// 紙魚抹殺
 		ClimateSmelting silverfish5 = new ClimateSmelting(new ItemStack(Blocks.STONEBRICK, 1, 2), null, DCHeatTier.KILN,
 				null, null, 0, false, new ItemStack(Blocks.MONSTER_EGG, 1, 4));
-		RecipeAPI.registerSmelting.addRecipe(silverfish5, DCHeatTier.KILN);
+		RecipeAPI.registerSmelting.addRecipe(silverfish5);
 
 		ClimateSmelting silverfish4 = new ClimateSmelting(new ItemStack(Blocks.STONEBRICK, 1, 1), null, DCHeatTier.KILN,
 				null, null, 0, false, new ItemStack(Blocks.MONSTER_EGG, 1, 3));
-		RecipeAPI.registerSmelting.addRecipe(silverfish4, DCHeatTier.KILN);
+		RecipeAPI.registerSmelting.addRecipe(silverfish4);
 
 		ClimateSmelting silverfish3 = new ClimateSmelting(new ItemStack(Blocks.STONEBRICK, 1, 0), null, DCHeatTier.KILN,
 				null, null, 0, false, new ItemStack(Blocks.MONSTER_EGG, 1, 2));
-		RecipeAPI.registerSmelting.addRecipe(silverfish3, DCHeatTier.KILN);
+		RecipeAPI.registerSmelting.addRecipe(silverfish3);
 
 		ClimateSmelting silverfish2 = new ClimateSmelting(new ItemStack(Blocks.COBBLESTONE, 1, 0), null,
 				DCHeatTier.KILN, null, null, 0, false, new ItemStack(Blocks.MONSTER_EGG, 1, 1));
-		RecipeAPI.registerSmelting.addRecipe(silverfish2, DCHeatTier.KILN);
+		RecipeAPI.registerSmelting.addRecipe(silverfish2);
 
 		ClimateSmelting silverfish1 = new ClimateSmelting(new ItemStack(Blocks.STONE, 1, 1), null, DCHeatTier.KILN,
 				null, null, 0, false, new ItemStack(Blocks.MONSTER_EGG, 1, 0));
-		RecipeAPI.registerSmelting.addRecipe(silverfish1, DCHeatTier.KILN);
+		RecipeAPI.registerSmelting.addRecipe(silverfish1);
 
 		// grassとsandの風化
 		ClimateSmelting sand = new ClimateSmelting(new ItemStack(Blocks.SAND, 1, 0), null, DCHeatTier.SMELTING,
 				DCHumidity.DRY, null, 0, false, new ItemStack(Blocks.DIRT, 1, 0));
 		sand.requiredHeat().add(DCHeatTier.INFERNO);
-		RecipeAPI.registerSmelting.addRecipe(sand, DCHeatTier.SMELTING);
+		RecipeAPI.registerSmelting.addRecipe(sand);
 
 		ClimateSmelting sand2 = new ClimateSmelting(new ItemStack(Blocks.DIRT, 1, 0), null, DCHeatTier.SMELTING,
 				DCHumidity.DRY, null, 0, false, new ItemStack(Blocks.GRASS, 1, 0)) {
@@ -156,7 +156,7 @@ public class DCRecipe {
 			}
 		};
 		sand2.requiredHeat().add(DCHeatTier.INFERNO);
-		RecipeAPI.registerSmelting.addRecipe(sand2, DCHeatTier.SMELTING);
+		RecipeAPI.registerSmelting.addRecipe(sand2);
 
 		ClimateSmelting dirt2 = new ClimateSmelting(new ItemStack(Blocks.DIRT, 1, 0), null, DCHeatTier.WARM,
 				DCHumidity.WET, null, 0, false, new ItemStack(Blocks.SAND, 1, 0)) {
@@ -169,13 +169,13 @@ public class DCRecipe {
 		};
 		dirt2.requiredHum().add(DCHumidity.UNDERWATER);
 		dirt2.requiredHeat().remove(DCHeatTier.NORMAL);
-		RecipeAPI.registerSmelting.addRecipe(dirt2, DCHeatTier.WARM);
+		RecipeAPI.registerSmelting.addRecipe(dirt2);
 
 		ClimateSmelting dirt3 = new ClimateSmelting(new ItemStack(Blocks.GRASS, 1, 0), null, DCHeatTier.WARM,
 				DCHumidity.WET, null, 0, false, new ItemStack(Blocks.DIRT, 1, 0));
 		dirt3.requiredHum().add(DCHumidity.UNDERWATER);
 		dirt3.requiredHeat().remove(DCHeatTier.NORMAL);
-		RecipeAPI.registerSmelting.addRecipe(dirt3, DCHeatTier.WARM);
+		RecipeAPI.registerSmelting.addRecipe(dirt3);
 
 		ClimateSmelting sap = new ClimateSmelting(new ItemStack(Blocks.SAPLING, 1, 0), null, DCHeatTier.WARM,
 				DCHumidity.WET, null, 0, false, new ItemStack(Blocks.DEADBUSH, 1, 0)) {
@@ -187,7 +187,7 @@ public class DCRecipe {
 				return false;
 			}
 		};
-		RecipeAPI.registerSmelting.addRecipe(sap, DCHeatTier.WARM);
+		RecipeAPI.registerSmelting.addRecipe(sap);
 
 		ClimateSmelting sap2 = new ClimateSmelting(new ItemStack(Blocks.DEADBUSH, 1, 0), null, DCHeatTier.OVEN,
 				DCHumidity.DRY, null, 0, false, new ItemStack(Blocks.SAPLING, 1, 32767)) {
@@ -200,7 +200,7 @@ public class DCRecipe {
 				return false;
 			}
 		};
-		RecipeAPI.registerSmelting.addRecipe(sap2, DCHeatTier.OVEN);
+		RecipeAPI.registerSmelting.addRecipe(sap2);
 	}
 
 	public static void addShapedRecipe(ResourceLocation name, @Nonnull ItemStack result, Object... recipe) {

--- a/java/defeatedcrow/hac/core/climate/recipe/ClimateSmeltingRegister.java
+++ b/java/defeatedcrow/hac/core/climate/recipe/ClimateSmeltingRegister.java
@@ -2,7 +2,9 @@ package defeatedcrow.hac.core.climate.recipe;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
+import com.google.common.base.Suppliers;
 import defeatedcrow.hac.api.climate.ClimateAPI;
 import defeatedcrow.hac.api.climate.DCAirflow;
 import defeatedcrow.hac.api.climate.DCHeatTier;
@@ -17,80 +19,22 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 public class ClimateSmeltingRegister implements IClimateSmeltingRegister {
+	/*
+	 * RecipeListは温度ごとに別になっている。
+	 */
+	//todo Make it a list of IClimateSmelting instead of ClimateSmelting?
+	private List<ClimateSmelting> recipes = new ArrayList<>();
 
 	public ClimateSmeltingRegister() {
-		this.absList = new ArrayList<ClimateSmelting>();
-		this.cryoList = new ArrayList<ClimateSmelting>();
-		this.frostList = new ArrayList<ClimateSmelting>();
-		this.coldList = new ArrayList<ClimateSmelting>();
-		this.coolList = new ArrayList<ClimateSmelting>();
-		this.normalList = new ArrayList<ClimateSmelting>();
-		this.warmList = new ArrayList<ClimateSmelting>();
-		this.hotList = new ArrayList<ClimateSmelting>();
-		this.boilList = new ArrayList<ClimateSmelting>();
-		this.ovenList = new ArrayList<ClimateSmelting>();
-		this.kilnList = new ArrayList<ClimateSmelting>();
-		this.smeltList = new ArrayList<ClimateSmelting>();
-		this.uhtList = new ArrayList<ClimateSmelting>();
-		this.infList = new ArrayList<ClimateSmelting>();
 	}
 
 	public IClimateSmeltingRegister instance() {
 		return RecipeAPI.registerSmelting;
 	}
 
-	/*
-	 * RecipeListは温度ごとに別になっている。
-	 */
-	private static List<ClimateSmelting> absList;
-	private static List<ClimateSmelting> cryoList;
-	private static List<ClimateSmelting> frostList;
-	private static List<ClimateSmelting> coldList;
-	private static List<ClimateSmelting> coolList;
-	private static List<ClimateSmelting> normalList;
-	private static List<ClimateSmelting> warmList;
-	private static List<ClimateSmelting> hotList;
-	private static List<ClimateSmelting> boilList;
-	private static List<ClimateSmelting> ovenList;
-	private static List<ClimateSmelting> kilnList;
-	private static List<ClimateSmelting> smeltList;
-	private static List<ClimateSmelting> uhtList;
-	private static List<ClimateSmelting> infList;
-
 	@Override
-	public List<ClimateSmelting> getRecipeList(DCHeatTier tier) {
-		switch (tier) {
-		case ABSOLUTE:
-			return absList;
-		case CRYOGENIC:
-			return cryoList;
-		case FROSTBITE:
-			return frostList;
-		case COLD:
-			return coldList;
-		case COOL:
-			return coolList;
-		case NORMAL:
-			return normalList;
-		case WARM:
-			return warmList;
-		case HOT:
-			return hotList;
-		case BOIL:
-			return boilList;
-		case OVEN:
-			return ovenList;
-		case KILN:
-			return kilnList;
-		case SMELTING:
-			return smeltList;
-		case UHT:
-			return uhtList;
-		case INFERNO:
-			return infList;
-		default:
-			return ovenList;
-		}
+	public List<ClimateSmelting> getRecipeList() {
+		return recipes;
 	}
 
 	@Override
@@ -109,8 +53,7 @@ public class ClimateSmeltingRegister implements IClimateSmeltingRegister {
 				secondary = ItemStack.EMPTY;
 			}
 			boolean drop = false;
-			List<ClimateSmelting> list = getRecipeList(heat);
-			list.add(new ClimateSmelting(output, secondary, heat, hum, air, secondaryChance, cooling, input));
+			getRecipeList().add(new ClimateSmelting(output, secondary, heat, hum, air, secondaryChance, cooling, input));
 		}
 	}
 
@@ -118,8 +61,7 @@ public class ClimateSmeltingRegister implements IClimateSmeltingRegister {
 	public void addRecipe(ItemStack output, DCHeatTier heat, DCHumidity hum, DCAirflow air, boolean needCooling,
 			Object input) {
 		if (input != null && !DCUtil.isEmpty(output) && heat != null) {
-			List<ClimateSmelting> list = getRecipeList(heat);
-			list.add(new ClimateSmelting(output, ItemStack.EMPTY, heat, hum, air, 1.0F, false, input));
+			getRecipeList().add(new ClimateSmelting(output, ItemStack.EMPTY, heat, hum, air, 1.0F, false, input));
 		}
 	}
 
@@ -135,42 +77,24 @@ public class ClimateSmeltingRegister implements IClimateSmeltingRegister {
 	}
 
 	@Override
-	public void addRecipe(IClimateSmelting recipe, DCHeatTier heat) {
-		List<ClimateSmelting> list = getRecipeList(heat);
-		if (recipe instanceof ClimateSmelting)
-			list.add((ClimateSmelting) recipe);
+	public void addRecipe(IClimateSmelting recipe) {
+		if(recipe instanceof ClimateSmelting)
+			getRecipeList().add((ClimateSmelting)recipe);
+	}
+
+	@Override
+	public IClimateSmelting getRecipe(Supplier<IClimate> clm, ItemStack item) {
+		for(IClimateSmelting recipe : recipes) {
+			if(recipe.matcheInput(item) && recipe.matchClimate(clm.get())) {
+				return recipe;
+			}
+		}
+		return null;
 	}
 
 	@Override
 	public IClimateSmelting getRecipe(IClimate clm, ItemStack item) {
-		List<ClimateSmelting> list = new ArrayList<ClimateSmelting>();
-		list.addAll(getRecipeList(clm.getHeat()));
-		/*
-		 * 現在環境の1つ下の温度帯のレシピも条件にあてまはる
-		 */
-		if (clm.getHeat() != DCHeatTier.ABSOLUTE) {
-			DCHeatTier d = clm.getHeat().addTier(-1);
-			list.addAll(getRecipeList(d));
-		}
-		if (clm.getHeat() != DCHeatTier.INFERNO) {
-			DCHeatTier u = clm.getHeat().addTier(1);
-			list.addAll(getRecipeList(u));
-		}
-		IClimateSmelting ret = null;
-		if (list.isEmpty()) {} else {
-			// DCLogger.debugLog("### searching... ###");
-			int c = 0;
-			for (IClimateSmelting recipe : list) {
-				if (recipe.matcheInput(item) && recipe.matchClimate(clm)) {
-					ret = recipe;
-				}
-			}
-		}
-
-		if (ret != null) {
-			return ret;
-		}
-		return null;
+		return getRecipe(Suppliers.ofInstance(clm), item);
 	}
 
 	@Override
@@ -178,5 +102,4 @@ public class ClimateSmeltingRegister implements IClimateSmeltingRegister {
 		IClimate clm = ClimateAPI.register.getClimateFromInt(code);
 		return getRecipe(clm, item);
 	}
-
 }

--- a/java/defeatedcrow/hac/core/event/BlockUpdateDC.java
+++ b/java/defeatedcrow/hac/core/event/BlockUpdateDC.java
@@ -139,7 +139,7 @@ public class BlockUpdateDC {
 			boolean f2 = false;
 			// レシピ判定
 			if (CoreConfigDC.enableVanilla && !(block instanceof IClimateObject)) {
-				IClimateSmelting recipe = RecipeAPI.registerSmelting.getRecipe(clm.get(), new ItemStack(block, 1, meta));
+				IClimateSmelting recipe = RecipeAPI.registerSmelting.getRecipe(clm, new ItemStack(block, 1, meta));
 				if (recipe != null && recipe.matchClimate(clm.get()) && recipe.additionalRequire(world, p)
 						&& recipe.hasPlaceableOutput() == 1) {
 					if (recipe.getOutput() != null && recipe.getOutput().getItem() instanceof ItemBlock) {

--- a/java/defeatedcrow/hac/core/event/BlockUpdateDC.java
+++ b/java/defeatedcrow/hac/core/event/BlockUpdateDC.java
@@ -1,9 +1,7 @@
 package defeatedcrow.hac.core.event;
 
-import defeatedcrow.hac.api.climate.ClimateAPI;
-import defeatedcrow.hac.api.climate.DCHeatTier;
-import defeatedcrow.hac.api.climate.DCHumidity;
-import defeatedcrow.hac.api.climate.IClimate;
+import com.google.common.base.Suppliers;
+import defeatedcrow.hac.api.climate.*;
 import defeatedcrow.hac.api.cultivate.IClimateCrop;
 import defeatedcrow.hac.api.recipe.DCBlockFreezeEvent;
 import defeatedcrow.hac.api.recipe.DCBlockUpdateEvent;
@@ -26,6 +24,8 @@ import net.minecraft.world.World;
 import net.minecraftforge.fml.common.eventhandler.Event.Result;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
+import java.util.function.Supplier;
+
 public class BlockUpdateDC {
 
 	@SubscribeEvent
@@ -45,7 +45,7 @@ public class BlockUpdateDC {
 				return;
 
 			int meta = block.getMetaFromState(st);
-			IClimate clm = ClimateAPI.calculator.getClimate(world, p);
+			ClimateSupplier clm = new ClimateSupplier(world, p);
 			boolean roof = hasRoof(world, p);
 
 			// 直接指定の仕様
@@ -62,12 +62,12 @@ public class BlockUpdateDC {
 				}
 			} else if (block instanceof IGrowable) {
 				// WETの参照posを真下に
-				IClimate clm2 = ClimateAPI.calculator.getClimate(world, p.down());
 				if (block == Blocks.TALLGRASS) {
 					// WARMかつWETの場合に成長が促進される
 					IGrowable grow = (IGrowable) block;
 					if (grow.canGrow(world, p, st, false) && world.rand.nextInt(5) == 0) {
-						if ((clm.getHeat() == DCHeatTier.WARM || clm.getHeat() == DCHeatTier.HOT)
+						IClimate clm2 = ClimateAPI.calculator.getClimate(world, p.down());
+						if ((clm.get().getHeat() == DCHeatTier.WARM || clm.get().getHeat() == DCHeatTier.HOT)
 								&& clm2.getHumidity() == DCHumidity.WET) {
 							grow.grow(world, world.rand, p, st);
 						}
@@ -78,7 +78,8 @@ public class BlockUpdateDC {
 					// WARMかつWETの場合に成長が促進されるが、バニラ植物ほど加速はしない
 					IGrowable grow = (IGrowable) block;
 					if (grow.canGrow(world, p, st, false) && world.rand.nextInt(10) == 0) {
-						if ((clm.getHeat() == DCHeatTier.WARM || clm.getHeat() == DCHeatTier.HOT)
+						IClimate clm2 = ClimateAPI.calculator.getClimate(world, p.down());
+						if ((clm.get().getHeat() == DCHeatTier.WARM || clm.get().getHeat() == DCHeatTier.HOT)
 								&& clm2.getHumidity() == DCHumidity.WET) {
 							grow.grow(world, world.rand, p, st);
 						}
@@ -87,11 +88,12 @@ public class BlockUpdateDC {
 					// WARMかつWETの場合に成長が促進され、COLD以下の場合は成長が遅くなる
 					IGrowable grow = (IGrowable) block;
 					if (grow.canGrow(world, p, st, false) && world.rand.nextInt(5) == 0) {
-						if ((clm.getHeat() == DCHeatTier.WARM || clm.getHeat() == DCHeatTier.HOT)
+						IClimate clm2 = ClimateAPI.calculator.getClimate(world, p.down());
+						if ((clm.get().getHeat() == DCHeatTier.WARM || clm.get().getHeat() == DCHeatTier.HOT)
 								&& clm2.getHumidity() == DCHumidity.WET) {
 							grow.grow(world, world.rand, p, st);
 							// DCLogger.debugLog("Grow!");
-						} else if (clm.getHeat().getTier() < -1) {
+						} else if (clm.get().getHeat().getTier() < -1) {
 							event.setCanceled(true);
 							// DCLogger.debugLog("Grow Canceled");
 						}
@@ -104,17 +106,17 @@ public class BlockUpdateDC {
 			 * WARM以上で強制溶解
 			 */
 			else if (block == Blocks.ICE) {
-				if (clm.getHeat().getTier() < 0) {
+				if (clm.get().getHeat().getTier() < 0) {
 					// 隣接4つもチェックする
 					int r1 = world.rand.nextInt(4);
-					if (clm.getHeat().getTier() == DCHeatTier.ABSOLUTE.getTier()) {
+					if (clm.get().getHeat().getTier() == DCHeatTier.ABSOLUTE.getTier()) {
 						world.setBlockState(p, Blocks.PACKED_ICE.getDefaultState(), 2);
 						world.notifyNeighborsOfStateChange(p, Blocks.PACKED_ICE, false);
 						event.setCanceled(true);
 						// DCLogger.debugLog("Freeze!!");
 					}
 					event.setCanceled(true);
-				} else if (clm.getHeat().getTier() > 0) {
+				} else if (clm.get().getHeat().getTier() > 0) {
 					world.setBlockState(p, Blocks.WATER.getDefaultState(), 2);
 					world.notifyNeighborsOfStateChange(p, Blocks.WATER, false);
 					event.setCanceled(true);
@@ -125,9 +127,9 @@ public class BlockUpdateDC {
 				 * COOL以下であれば氷が溶けなくなり、WARM以上で強制溶解
 				 */
 			} else if (block == Blocks.SNOW || block == Blocks.SNOW_LAYER) {
-				if (clm.getHeat().getTier() < 0) {
+				if (clm.get().getHeat().getTier() < 0) {
 					event.setCanceled(true);
-				} else if (clm.getHeat().getTier() > 0) {
+				} else if (clm.get().getHeat().getTier() > 0) {
 					world.setBlockToAir(p);
 					event.setCanceled(true);
 					// DCLogger.debugLog("Melted");
@@ -137,8 +139,8 @@ public class BlockUpdateDC {
 			boolean f2 = false;
 			// レシピ判定
 			if (CoreConfigDC.enableVanilla && !(block instanceof IClimateObject)) {
-				IClimateSmelting recipe = RecipeAPI.registerSmelting.getRecipe(clm, new ItemStack(block, 1, meta));
-				if (recipe != null && recipe.matchClimate(clm) && recipe.additionalRequire(world, p)
+				IClimateSmelting recipe = RecipeAPI.registerSmelting.getRecipe(clm.get(), new ItemStack(block, 1, meta));
+				if (recipe != null && recipe.matchClimate(clm.get()) && recipe.additionalRequire(world, p)
 						&& recipe.hasPlaceableOutput() == 1) {
 					if (recipe.getOutput() != null && recipe.getOutput().getItem() instanceof ItemBlock) {
 						Block retB = Block.getBlockFromItem(recipe.getOutput().getItem());
@@ -155,9 +157,9 @@ public class BlockUpdateDC {
 
 			// ハードモード
 			if (CoreConfigDC.harderVanilla) {
-				if (clm.getHeat().getTier() > DCHeatTier.SMELTING.getTier()) {
+				if (clm.get().getHeat().getTier() > DCHeatTier.SMELTING.getTier()) {
 
-					if (clm.getHeat() == DCHeatTier.INFERNO) {
+					if (clm.get().getHeat() == DCHeatTier.INFERNO) {
 						// 融解
 						if (st.getMaterial() == Material.ROCK || st.getMaterial() == Material.SAND
 								|| st.getMaterial() == Material.GROUND) {

--- a/java/defeatedcrow/hac/core/plugin/jei/ClimateSmeltingMaker.java
+++ b/java/defeatedcrow/hac/core/plugin/jei/ClimateSmeltingMaker.java
@@ -13,22 +13,7 @@ public final class ClimateSmeltingMaker {
 	private ClimateSmeltingMaker() {}
 
 	public static void register(IModRegistry registry) {
-		List<ClimateSmelting> list = new ArrayList<ClimateSmelting>();
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.ABSOLUTE));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.CRYOGENIC));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.FROSTBITE));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.COLD));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.COOL));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.NORMAL));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.WARM));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.HOT));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.BOIL));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.OVEN));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.KILN));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.SMELTING));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.UHT));
-		list.addAll((List<ClimateSmelting>) RecipeAPI.registerSmelting.getRecipeList(DCHeatTier.INFERNO));
-		registry.addRecipes(list, DCsJEIPlugin.SMELTING_UID);
+		registry.addRecipes(RecipeAPI.registerSmelting.getRecipeList(), DCsJEIPlugin.SMELTING_UID);
 	}
 
 }

--- a/resources/License.txt
+++ b/resources/License.txt
@@ -1,12 +1,24 @@
 Copyright (c) defeatedcrow, 2016
 URL:http://defeatedcrow.jp/modwiki/Mainpage
-All of defeatedcrow's mods are distributed under the terms of the following licenses.
 
-This mod is distributed under the following license: CC-BY-NC-SA 4.0
-https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+このmodは以下のライセンスの元で公開されます。 <br>
+This mod is distributed under the following license:
+#Code: All Rights Reserved
+Permissions
+- ソースコードを改変したり、あなたのmodプロジェクトに利用することができます。
+  You can fork, modify, or use the code in your project.
+- このmodの非改変パッケージをmodpackに同梱したり、マルチプレイサーバー内で再配布することができます
+  You can redistribute this mod's unmodified package to modpack or multiplayer server.
 
-The SA clause of the license is excluded in the following cases:
-1. When used to creating add-ons or plugins for this mod (as your MinecraftJE mod).
-2. When this mod is bundled with modpack for MinecraftJE.
-3. When you take the game playing videos of MinecraftJE that introduced this mod.
+Conditions
+- 著作権者の表示 Copyright notice
+- 商用利用禁止 Commercial use prohibition
 
+Limitations
+- このmodは「現状のまま」提供され、一切の動作を保証しません。
+  This mod is provided "as is" without warranty of any kind.
+- 作者および著作権者は、いかなる場合でも、このmodの使用その他によって生じる責任を負いません。
+  In any case, the author or copyright holder is not responsible for any claims, damages or other liabilities arising out of this mod or its use.
+
+#Assets: CC-BY-NC-SA 4.0 <br>
+ https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode


### PR DESCRIPTION
# Motivation
When I installed H&C on my server, it began to lag heavily. After profiling the server with [WarmRoast](https://github.com/sk89q/WarmRoast), I realized that the lags were caused by climate calculations in the `defeatedcrow.hac.core.event.BlockUpdateDC#onUpdate(defeatedcrow.hac.api.recipe.DCBlockUpdateEvent)` method.
# The Fixes Description
This PR fixes these issues:
1. It looks like that the `clm` variable (`IClimate clm = ClimateAPI.calculator.getClimate(world, p);`) is calculated on each block update, but sometimes not used further. I made it lazy, so the climate calculates only on first access.
2. Also, the `clm2` variable (`IClimate clm2 = ClimateAPI.calculator.getClimate(world, p.down());`) is calculated for every IGrowable block regardless of whether it really needed. I moved the climate calculation into the right scope, so it will work fine now.
3. Lastly, the recipe lookup (`IClimateSmelting recipe = RecipeAPI.registerSmelting.getRecipe(clm, new ItemStack(block, 1, meta));`) uses an instance of `IClimate`. I refactored some code to make it check the input `ItemStack` firstly, and, only if it matches, calculate the climate and check it.
# Profiling Results
## Before
![image](https://user-images.githubusercontent.com/7630912/43365181-32a14b12-9342-11e8-98e8-744971c9720d.png)
## After
![screenshot from 2018-07-29 14-12-45](https://user-images.githubusercontent.com/7630912/43365152-aaed7ed4-9341-11e8-937a-7c47a8d7c0b2.png)
# Notes
That pull request needs to be merged too: https://github.com/defeatedcrow/HeatAndClimateMod/pull/37.